### PR TITLE
Update talc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ version = "0.2.0"
 dependencies = [
  "firefly-rust",
  "firefly-types",
+ "spin",
  "talc",
 ]
 
@@ -118,6 +119,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "talc"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04be12ec299aadd63a0bf781d893e4b6139d33cdca6dcd6f6be31f849cedcac8"
+checksum = "3fcad3be1cfe36eb7d716a04791eba36a197da9d9b6ea1e28e64ac569da3701d"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,6 @@ version = "0.2.0"
 dependencies = [
  "firefly-rust",
  "firefly-types",
- "spin",
  "talc",
 ]
 
@@ -116,15 +115,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ firefly-rust = { version = "0.6.0", default-features = false, features = [
     "sudo",
 ] }
 firefly-types = "0.4.0"
-spin = { version = "0.9.8", default-fetaures = false }
 talc = { version = "4.4.2", default-features = false, features = ["lock_api"] }
 
 # https://github.com/johnthagen/min-sized-rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ firefly-rust = { version = "0.6.0", default-features = false, features = [
     "sudo",
 ] }
 firefly-types = "0.4.0"
-talc = { version = "4.4.1", default-features = false, features = ["lock_api"] }
+spin = { version = "0.9.8", default-fetaures = false }
+talc = { version = "4.4.2", default-features = false, features = ["lock_api"] }
 
 # https://github.com/johnthagen/min-sized-rust
 [profile.release]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,15 +30,15 @@ use core::ptr::addr_of;
 use firefly_rust::add_menu_item;
 use list_scene::Command;
 use state::*;
-use talc::{ClaimOnOom, Span, Talc, Talck};
+use talc::{locking::AssumeUnlockable, ClaimOnOom, Span, Talc, Talck};
 
 // one wasm page
 static mut ARENA: [u8; 65536] = [0; 65536];
 
 #[global_allocator]
-static ALLOCATOR: Talck<spin::Mutex<()>, ClaimOnOom> = Talc::new(unsafe {
+static ALLOCATOR: Talck<AssumeUnlockable, ClaimOnOom> = Talc::new(unsafe {
     //
-    ClaimOnOom::new(Span::from_array(addr_of!(ARENA) as *mut [u8; 10000]))
+    ClaimOnOom::new(Span::from_array(addr_of!(ARENA).cast_mut()))
 })
 .lock();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,21 +26,12 @@ mod list_scene;
 mod state;
 
 use apps::*;
-use core::ptr::addr_of;
 use firefly_rust::add_menu_item;
 use list_scene::Command;
 use state::*;
-use talc::{locking::AssumeUnlockable, ClaimOnOom, Span, Talc, Talck};
-
-// one wasm page
-static mut ARENA: [u8; 65536] = [0; 65536];
 
 #[global_allocator]
-static ALLOCATOR: Talck<AssumeUnlockable, ClaimOnOom> = Talc::new(unsafe {
-    //
-    ClaimOnOom::new(Span::from_array(addr_of!(ARENA).cast_mut()))
-})
-.lock();
+static ALLOCATOR: talc::TalckWasm = unsafe { talc::TalckWasm::new_global() };
 
 pub enum Scene {
     List,

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@
     clippy::module_name_repetitions
 )]
 
+extern crate alloc;
+
 mod apps;
 mod delete_scene;
 mod info_scene;
@@ -24,23 +26,19 @@ mod list_scene;
 mod state;
 
 use apps::*;
+use core::ptr::addr_of;
+use firefly_rust::add_menu_item;
 use list_scene::Command;
 use state::*;
-
-extern crate alloc;
-
-use firefly_rust::add_menu_item;
-use talc::locking::AssumeUnlockable;
 use talc::{ClaimOnOom, Span, Talc, Talck};
 
 // one wasm page
 static mut ARENA: [u8; 65536] = [0; 65536];
 
-// Setup Talc as the global allocator.
 #[global_allocator]
-static ALLOCATOR: Talck<AssumeUnlockable, ClaimOnOom> = Talc::new(unsafe {
+static ALLOCATOR: Talck<spin::Mutex<()>, ClaimOnOom> = Talc::new(unsafe {
     //
-    ClaimOnOom::new(Span::from_const_array(core::ptr::addr_of!(ARENA)))
+    ClaimOnOom::new(Span::from_array(addr_of!(ARENA) as *mut [u8; 10000]))
 })
 .lock();
 


### PR DESCRIPTION
1. Update talc version
2. Use WasmHandler to let it dynamically allocate more memory

It still allocates 18 pages on the startup, though. IDK why. I think it's just Rust compiler thing.